### PR TITLE
Remove NoneError and support stable Rust (resolves #2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ name="rusthl7"
 path="src/lib.rs"
 
 [dependencies]
-failure = "0.1"
+thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ path="src/lib.rs"
 
 [dependencies]
 thiserror = "1.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "simple_parse"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,4 @@ name="rusthl7"
 path="src/lib.rs"
 
 [dependencies]
-#itertools = "0.8"
-#libc = "0.2"
 failure = "0.1"

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -1,16 +1,15 @@
-#![feature(test)]
-extern crate test;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rusthl7::message::*;
 
-#[cfg(test)]
-mod benches {
-    use rusthl7::message::*;
+
     fn get_sample_message() -> String {
         "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F".to_string()
     }
 
-    #[bench]
-    fn message_parse(b: &mut test::Bencher) {
+    fn message_parse(c: &mut Criterion) {
         let msg = &get_sample_message();
-        b.iter(|| Message::from_str(msg));
+        c.bench_function("oru parse", |b| b.iter(|| Message::from_str(msg)));
     }
-}
+    
+    criterion_group!(benches, message_parse);
+    criterion_main!(benches);

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -10,8 +10,17 @@ pub enum Field<'a> {
 
 impl<'a> Field<'a> {
     /// Convert the given line of text into a field.
-    pub fn parse(input: &'a str, delims: &Separators) -> Result<Field<'a>, Hl7ParseError> {
+    pub fn parse(input: &'a str, _delims: &Separators) -> Result<Field<'a>, Hl7ParseError> {
+        // TODO: Match on component delim and return one of two Field variants (Generic or Componentised??)... names are hard
         Ok(Field::Generic(input))
+    }
+
+    /// Used to hide the removal of NoneError for #2...  If passed `Some()` value it retursn a field with that value.  If passed `None() it returns an `Err(Hl7ParseError::MissingRequiredValue{})`
+    pub fn parse_mandatory(input: Option<&'a str>, delims: &Separators) -> Result<Field<'a>, Hl7ParseError> {
+        match input {
+            Some(string_value) => Field::parse(string_value, delims),
+            None => Err(Hl7ParseError::MissingRequiredValue{})
+        }
     }
 
     /// Converts a possibly blank string into a possibly blank field!  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,21 +3,18 @@ pub mod message;
 pub mod segments;
 pub mod separators;
 
-use failure::Fail;
 
-#[derive(Debug, Fail)]
+
+#[derive(Debug, thiserror::Error)]
 pub enum Hl7ParseError {
-    #[fail(display = "Unexpected error: {}", error)]
-    Generic { error: String },
+    #[error("Unexpected error: {0}")]
+    Generic (String),
 
-    #[fail(
-        display = "Failure parsing MSH1/MSH2 while discovering separator chars: {}",
-        error
-    )]
-    Msh1Msh2 { error: String },
+    #[error("Failure parsing MSH1/MSH2 while discovering separator chars: {0}")]
+    Msh1Msh2 (String),
 
-    #[fail(display = "Required value missing")]
-    MissingRequiredValue //{ /*error: NoneError*/ }, // remmed for #2 until NoneError gets more stable.
+    #[error("Required value missing")]
+    MissingRequiredValue()
 }
 
 /*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,9 @@
-#![feature(try_trait)] //apparently required for our From impl below
-
 pub mod fields;
 pub mod message;
 pub mod segments;
 pub mod separators;
 
 use failure::Fail;
-use std::option::NoneError;
 
 #[derive(Debug, Fail)]
 pub enum Hl7ParseError {
@@ -20,15 +17,16 @@ pub enum Hl7ParseError {
     Msh1Msh2 { error: String },
 
     #[fail(display = "Required value missing")]
-    MissingRequiredValue { error: NoneError },
+    MissingRequiredValue //{ /*error: NoneError*/ }, // remmed for #2 until NoneError gets more stable.
 }
 
+/*
 impl From<NoneError> for Hl7ParseError {
     fn from(error: NoneError) -> Self {
         // this would only be called if we `?` a `None` somewhere.
         Hl7ParseError::MissingRequiredValue { error }
     }
-}
+}*/
 
 // /// A repeat of a field is a set of 0 or more sub component values.
 // /// Currently all values are stored as their original string representations.  Methods to convert

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -38,7 +38,7 @@ pub struct MshSegment<'a> {
 impl<'a> MshSegment<'a> {
     pub fn parse(input: &'a str, delims: &Separators) -> Result<MshSegment<'a>, Hl7ParseError> {
         let mut fields = input.split(delims.field);
-
+    
         assert!(fields.next().unwrap() == "MSH");
 
         let _ = fields.next(); //consume the delimiter chars
@@ -50,12 +50,12 @@ impl<'a> MshSegment<'a> {
             msh_4_sending_facility: Field::parse_optional(fields.next(), delims)?,
             msh_5_receiving_application: Field::parse_optional(fields.next(), delims)?,
             msh_6_receiving_facility: Field::parse_optional(fields.next(), delims)?,
-            msh_7_date_time_of_message: Field::parse(fields.next()?, delims)?,
+            msh_7_date_time_of_message: Field::parse_mandatory(fields.next(), delims)?,
             msh_8_security: Field::parse_optional(fields.next(), delims)?,
-            msh_9_message_type: Field::parse(fields.next()?, delims)?,
-            msh_10_message_control_id: Field::parse(fields.next()?, delims)?,
-            msh_11_processing_id: Field::parse(fields.next()?, delims)?,
-            msh_12_version_id: Field::parse(fields.next()?, delims)?,
+            msh_9_message_type: Field::parse_mandatory(fields.next(), delims)?,
+            msh_10_message_control_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_11_processing_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_12_version_id: Field::parse_mandatory(fields.next(), delims)?,
             msh_13_sequence_number: Field::parse_optional(fields.next(), delims)?,
             msh_14_continuation_pointer: Field::parse_optional(fields.next(), delims)?,
             msh_15_accept_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
@@ -74,7 +74,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ensure_msh_fields_are_populated() -> Result<(), Hl7ParseError> {
+    fn ensure_msh_fields_are_populated() -> Result<(), Box<dyn std::error::Error>> {
         let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
         let delims = Separators::default();
 

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -74,17 +74,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ensure_msh_fields_are_populated() -> Result<(), Box<dyn std::error::Error>> {
+    fn ensure_msh_fields_are_populated() -> Result<(), Hl7ParseError> {
         let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
         let delims = Separators::default();
 
         let msh = MshSegment::parse(hl7, &delims)?;
 
         assert_eq!(msh.msh_1_field_separator, '|');
-        assert_eq!(msh.msh_3_sending_application?.value(), "GHH LAB");
-        assert_eq!(msh.msh_4_sending_facility?.value(), "ELAB-3");
-        assert_eq!(msh.msh_5_receiving_application?.value(), "GHH OE");
-        assert_eq!(msh.msh_6_receiving_facility?.value(), "BLDG4");
+
+        let msh3 = msh.msh_3_sending_application.ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
+        assert_eq!(msh3.value(), "GHH LAB");
+        
+        let msh4 = msh.msh_4_sending_facility.ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
+        assert_eq!(msh4.value(), "ELAB-3");
+
+        let msh5 = msh.msh_5_receiving_application.ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
+        assert_eq!(msh5.value(), "GHH OE");
+
+        let msh6 = msh.msh_6_receiving_facility.ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
+        assert_eq!(msh6.value(), "BLDG4");
+
         assert_eq!(msh.msh_8_security, None); //blank field check
         assert_eq!(msh.msh_12_version_id.value(), "2.4"); //we got to the end ok
         Ok(())

--- a/src/separators.rs
+++ b/src/separators.rs
@@ -39,9 +39,7 @@ impl Separators {
             || Some((1, 'S')) != chars.next()
             || Some((2, 'H')) != chars.next()
         {
-            return Err(Hl7ParseError::Msh1Msh2 {
-                error: "Message doesn't start with 'MSH'".to_string(),
-            });
+            return Err(Hl7ParseError::Msh1Msh2 ("Message doesn't start with 'MSH'".to_string()));
         }
 
         Ok(Separators {


### PR DESCRIPTION
Rapid-fire updates to get library, tests and benchmarks all running on stable rust 1.53