### PR TITLE
Parse components and subcomponents from Field

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -46,6 +46,26 @@ impl<'a> Field<'a> {
             Field::Generic(s) => s,
         }
     }
+
+    /// Method to get the underlying components of the value in this field.
+    pub fn components(&self, delims: &Separators) -> Vec<&'a str> {
+        match self {
+            Field::Generic(s) => s.split(delims.component).collect(),
+        }
+    }
+
+    /// Method to get the subcomponents from the value in this field.
+    pub fn subcomponents(&self, delims: &Separators) -> Vec<Vec<&'a str>> {
+        match self {
+            Field::Generic(s) => {
+                let components = s.split(delims.component).collect::<Vec<&'a str>>();
+                components
+                    .iter()
+                    .map(|sc| sc.split(delims.subcomponent).collect::<Vec<&'a str>>())
+                    .collect()
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -103,5 +123,19 @@ mod tests {
             Err(Hl7ParseError::MissingRequiredValue()) => assert!(true),
             _ => assert!(false),
         }
+    }
+
+    #[test]
+    fn test_parse_components() {
+        let d = Separators::default();
+        let f = Field::parse_mandatory(Some("xxx^yyy"), &d).unwrap();
+        assert_eq!(f.components(&d).len(), 2)
+    }
+
+    #[test]
+    fn test_parse_subcomponents() {
+        let d = Separators::default();
+        let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
+        assert_eq!(f.subcomponents(&d)[1].len(), 2)
     }
 }


### PR DESCRIPTION
Implement functional sub-field parsers for the `component` and
`subcomopnent` delimeters to produce vectors of &str's via value
accessor and subdivider functions `copmonents` and `subcomponents`;
both of which take a &Separators argument for MSH-appropriate
dissection.

Testing:
  Added tests for both functions - passing