### PR TITLE
Feature/field encapsulation

### DIFF
--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -66,6 +66,13 @@ impl<'a> Field<'a> {
             }
         }
     }
+
+    /// Extract field value to owned String
+    pub fn to_string(&self) -> String {
+        match self {
+            Field::Generic(s) => s.clone().to_owned()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -137,5 +144,12 @@ mod tests {
         let d = Separators::default();
         let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
         assert_eq!(f.subcomponents(&d)[1].len(), 2)
+    }
+
+    #[test]
+    fn test_to_string() {
+        let d = Separators::default();
+        let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
+        assert_eq!(f.to_string(), String::from("xxx^yyy&zzz"))
     }
 }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -47,6 +47,16 @@ impl<'a> Field<'a> {
         }
     }
 
+    /// Export valus to owned String
+    pub fn to_string(&self) -> String {
+        self.value().clone().to_owned()
+    }
+
+    /// Export valus to str
+    pub fn as_str(&self) -> &'a str {
+        self.value()
+    }
+
     /// Method to get the underlying components of the value in this field.
     pub fn components(&self, delims: &Separators) -> Vec<&'a str> {
         match self {
@@ -64,13 +74,6 @@ impl<'a> Field<'a> {
                     .map(|sc| sc.split(delims.subcomponent).collect::<Vec<&'a str>>())
                     .collect()
             }
-        }
-    }
-
-    /// Extract field value to owned String
-    pub fn to_string(&self) -> String {
-        match self {
-            Field::Generic(s) => s.clone().to_owned()
         }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -95,6 +95,11 @@ impl<'a> Message<'a> {
     pub fn to_string(&self) -> String {
         self.source.clone().to_owned()
     }
+
+    /// Export source to str
+    pub fn as_str(&self) -> &'a str {
+        self.source
+    }
 }
 
 impl<'a> Clone for Message<'a> {

--- a/src/message.rs
+++ b/src/message.rs
@@ -90,6 +90,11 @@ impl<'a> Message<'a> {
             .collect();
         Ok(vecs)
     }
+
+    /// Export source to owned String
+    pub fn to_string(&self) -> String {
+        self.source.clone().to_owned()
+    }
 }
 
 impl<'a> Clone for Message<'a> {
@@ -162,6 +167,14 @@ mod tests {
             msg.msh().unwrap().msh_7_date_time_of_message,
             dolly.msh().unwrap().msh_7_date_time_of_message
         );
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_to_string() -> Result<(), Hl7ParseError> {
+        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment";
+        let msg = Message::from_str(hl7)?;
+        assert_eq!(msg.to_string(),String::from(hl7));
         Ok(())
     }
 }

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -1,7 +1,19 @@
 use super::fields::Field;
+use super::separators::Separators;
 
 /// A generic bag o' fields, representing an arbitrary segment.
 #[derive(Debug, PartialEq)]
 pub struct GenericSegment<'a> {
     pub fields: Vec<Field<'a>>,
+}
+
+impl<'a> GenericSegment<'a> {
+    pub fn to_string(&self, delims: &Separators) -> String {
+        let field = String::from(delims.field);
+        let fields = self.fields[..]
+            .iter()
+            .map(|f| f.value())
+            .collect::<Vec<&'a str>>();
+        fields.join(&field)
+    }
 }

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -1,19 +1,21 @@
 use super::fields::Field;
-use super::separators::Separators;
 
 /// A generic bag o' fields, representing an arbitrary segment.
 #[derive(Debug, PartialEq)]
 pub struct GenericSegment<'a> {
+    pub source: &'a str,
+    pub delim: char,
     pub fields: Vec<Field<'a>>,
 }
 
 impl<'a> GenericSegment<'a> {
-    pub fn to_string(&self, delims: &Separators) -> String {
-        let field = String::from(delims.field);
-        let fields = self.fields[..]
-            .iter()
-            .map(|f| f.value())
-            .collect::<Vec<&'a str>>();
-        fields.join(&field)
+    /// Export source to owned String
+    pub fn to_string(&self) -> String {
+        self.source.clone().to_owned()
+    }
+
+    /// Export source to str
+    pub fn as_str(&self) -> &'a str {
+        self.source
     }
 }

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -26,16 +26,25 @@ impl<'a> Segment<'a> {
 
         let seg = match fields[0].value() {
             "MSH" => Segment::MSH(MshSegment::parse(&input, delims)?),
-            _ => Segment::Generic(GenericSegment { fields }),
+            _ => Segment::Generic(GenericSegment {source: &input, delim: delims.field, fields }),
         };
 
         Ok(seg)
     }
 
-    pub fn to_string(&self, delims: &Separators) -> String {
+    /// Export source to owned String
+    pub fn to_string(&self) -> String {
         match self {
             Segment::MSH(m) => m.to_string(),
-            Segment::Generic(g) => g.to_string(delims)
+            Segment::Generic(g) => g.to_string()
+        }
+    }
+
+    /// Export source to str
+    pub fn as_str(&self) -> &'a str {
+        match self {
+            Segment::MSH(m) => m.as_str(),
+            Segment::Generic(g) => g.as_str(),
         }
     }
 }

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -31,6 +31,13 @@ impl<'a> Segment<'a> {
 
         Ok(seg)
     }
+
+    pub fn to_string(&self, delims: &Separators) -> String {
+        match self {
+            Segment::MSH(m) => m.to_string(),
+            Segment::Generic(g) => g.to_string(delims)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -7,6 +7,7 @@ use super::*;
 /// of a fully typed segment, not just a bag of fields....
 #[derive(Debug, PartialEq, Clone)]
 pub struct MshSegment<'a> {
+    pub source: &'a str,
     //this initial layout largely stolen from the _other_ hl7 crate: https://github.com/njaremko/hl7
     pub msh_1_field_separator: char,
     pub msh_2_encoding_characters: Separators,
@@ -44,6 +45,7 @@ impl<'a> MshSegment<'a> {
         let _ = fields.next(); //consume the delimiter chars
 
         let msh = MshSegment {
+            source: &input,
             msh_1_field_separator: delims.field,
             msh_2_encoding_characters: delims.to_owned(),
             msh_3_sending_application: Field::parse_optional(fields.next(), delims)?,
@@ -67,65 +69,14 @@ impl<'a> MshSegment<'a> {
 
         Ok(msh)
     }
-
-    /// Extract header segment to new String
+    /// Export source to owned String
     pub fn to_string(&self) -> String {
-        let d = &String::from(self.msh_2_encoding_characters.field);
-        String::from("MSH") + d +
-        &self.msh_2_encoding_characters.to_string() + d +
-        match self.msh_3_sending_application {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_4_sending_facility {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_5_receiving_application {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_6_receiving_facility {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        self.msh_7_date_time_of_message.value() + d +
-        match self.msh_8_security {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        self.msh_9_message_type.value() + d +
-        self.msh_10_message_control_id.value() + d +
-        self.msh_11_processing_id.value() + d +
-        self.msh_12_version_id.value() + d +
-        match self.msh_13_sequence_number {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_14_continuation_pointer {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_15_accept_acknowledgment_type {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_16_application_acknowledgment_type {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_17_country_code {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_18_character_set {
-            None => "",
-            Some(Field::Generic(x)) => x
-        } + d +
-        match self.msh_19_principal_language_of_message {
-            None => "",
-            Some(Field::Generic(x)) => x
-        }
+        self.source.clone().to_owned()
+    }
+
+    /// Export source to str
+    pub fn as_str(&self) -> &'a str {
+        self.source
     }
 }
 
@@ -164,16 +115,6 @@ mod tests {
 
         assert_eq!(msh.msh_8_security, None); //blank field check
         assert_eq!(msh.msh_12_version_id.value(), "2.4"); //we got to the end ok
-        Ok(())
-    }
-
-    #[test]
-    fn ensure_msh_to_string() -> Result<(), Hl7ParseError> {
-        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
-        let delims = Separators::default();
-        let msh = MshSegment::parse(hl7, &delims)?;
-        let clone = msh.to_string();
-        assert_eq!(hl7,&clone[..hl7.len()]);
         Ok(())
     }
 }

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -67,6 +67,66 @@ impl<'a> MshSegment<'a> {
 
         Ok(msh)
     }
+
+    /// Extract header segment to new String
+    pub fn to_string(&self) -> String {
+        let d = &String::from(self.msh_2_encoding_characters.field);
+        String::from("MSH") + d +
+        &self.msh_2_encoding_characters.to_string() + d +
+        match self.msh_3_sending_application {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_4_sending_facility {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_5_receiving_application {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_6_receiving_facility {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        self.msh_7_date_time_of_message.value() + d +
+        match self.msh_8_security {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        self.msh_9_message_type.value() + d +
+        self.msh_10_message_control_id.value() + d +
+        self.msh_11_processing_id.value() + d +
+        self.msh_12_version_id.value() + d +
+        match self.msh_13_sequence_number {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_14_continuation_pointer {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_15_accept_acknowledgment_type {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_16_application_acknowledgment_type {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_17_country_code {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_18_character_set {
+            None => "",
+            Some(Field::Generic(x)) => x
+        } + d +
+        match self.msh_19_principal_language_of_message {
+            None => "",
+            Some(Field::Generic(x)) => x
+        }
+    }
 }
 
 #[cfg(test)]
@@ -104,6 +164,16 @@ mod tests {
 
         assert_eq!(msh.msh_8_security, None); //blank field check
         assert_eq!(msh.msh_12_version_id.value(), "2.4"); //we got to the end ok
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_msh_to_string() -> Result<(), Hl7ParseError> {
+        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
+        let delims = Separators::default();
+        let msh = MshSegment::parse(hl7, &delims)?;
+        let clone = msh.to_string();
+        assert_eq!(hl7,&clone[..hl7.len()]);
         Ok(())
     }
 }

--- a/src/separators.rs
+++ b/src/separators.rs
@@ -53,6 +53,13 @@ impl Separators {
             subcomponent: chars.next().unwrap().1,
         })
     }
+
+    pub fn to_string(&self) -> String {
+        String::from(self.component) +
+        &String::from(self.repeat) +
+        &String::from(self.escape_char) +
+        &String::from(self.subcomponent)
+    }
 }
 
 /// Expects to receive a full message (or at least a MSH segment) in order to parse
@@ -105,5 +112,10 @@ mod tests {
         //note the missing M
         let result = Separators::new("SH|^~\\&|CATH|StJohn|AcmeHIS|StJohn|20061019172719||ACK^O01|MSGID12349876|P|2.3\rMSA|AA|MSGID12349876");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn ensure_separators_to_string() {
+        assert_eq!("^~\\&",Separators::default().to_string());
     }
 }


### PR DESCRIPTION
Using Field as an Enum made sense in the context of planning to
make multiple variants containing Field components or more nested
subcomponents in a single Enum. Using a functional approach to
extract those sub-fields allows for replacing the Enum with a
Struct and permitting encapsulated storage of sub-field delimeters
for external callers which don't have easy access to them but need
a sub-field value returned.

Implement the data conversion, parsing changes, and functional
changes to sub-field accessors.

Testing:
  Passes tests