### PR TITLE
fix #14: Breaking change to impl `TryFrom` rather than having a `from_str` function

### DIFF
--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -1,15 +1,17 @@
+use std::convert::TryFrom;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rusthl7::{message::*, segments::Segment};
 
-fn get_sample_message() -> String {
-    "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F".to_string()
+fn get_sample_message() -> &'static str {
+    "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F"
 }
 
 fn message_parse(c: &mut Criterion) {
-    let msg = &get_sample_message();
+    
     c.bench_function("oru parse", |b| {
+       
         b.iter(|| {
-            let m = Message::try_from(msg).unwrap();
+            let m = Message::try_from(get_sample_message()).unwrap();
             let seg = m.segments.first();
 
             if let Some(Segment::MSH(msh)) = seg {

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -9,7 +9,7 @@ fn message_parse(c: &mut Criterion) {
     let msg = &get_sample_message();
     c.bench_function("oru parse", |b| {
         b.iter(|| {
-            let m = Message::from_str(msg).unwrap();
+            let m = Message::try_from(msg).unwrap();
             let seg = m.segments.first();
 
             if let Some(Segment::MSH(msh)) = seg {

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -116,11 +116,12 @@ impl<'a> Index<&str> for GenericSegment<'a> {
 mod tests {
     use super::super::super::message::Message;
     use super::super::*;
+    use std::convert::TryFrom;
 
     #[test]
     fn ensure_numeric_index() {
         let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment^sub&segment";
-        let msg = Message::from_str(hl7).unwrap();
+        let msg = Message::try_from(hl7).unwrap();
         let (f, c, s) = match &msg.segments[1] {
             Segment::Generic(x) => (x[1], x[(1, 1)], x[(1, 1, 0)]),
             _ => ("", "", ""),
@@ -133,7 +134,7 @@ mod tests {
     #[test]
     fn ensure_string_index() {
         let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment^sub&segment";
-        let msg = Message::from_str(hl7).unwrap();
+        let msg = Message::try_from(hl7).unwrap();
         let (f, c, s, oob) = match &msg.segments[1] {
             Segment::Generic(x) => (
                 x[String::from("F1")],


### PR DESCRIPTION
Per [clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait) effectively overloading standard trait functions with our own impl is both unexpected to consumers, and means we're missing out on standard behaviour (like automatic `Into` impl after implementing `From`).

This PR alters `Message` to impl `TryFrom<&str>` and removes the original `from_str` function.

This is a breaking change so the sooner the better.