### PR TITLE
Provide functional method aliases to Index

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -97,6 +97,14 @@ impl<'a> Message<'a> {
     pub fn as_str(&self) -> &'a str {
         self.source
     }
+
+    fn query(&self, idx: &str) -> &'a str {
+        self[idx]
+    }
+
+    fn query_by_string(&self, idx: String) -> &'a str {
+        self[idx]
+    }
 }
 
 impl<'a> Display for Message<'a> {


### PR DESCRIPTION
This is an alternative to #18 - keeps both avenues for accessors, and doesn't move code around (needless git churn).