### PR TITLE
Work pending for 0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
+## 0.5.0
+ - Add `query` functions to replace the string based `Index` impls in the version version.  These are functionally identical to the string `Index` implementations, but avoid some lifetime issues (returning `&&str`) and have visible documentation.
+
 ## 0.4.0
  - Large change (thanks @sempervictus) to allow querying of message content by both numerical indexer and dot-notation string indexers
     - Note that the string indexers will be replaced with a normal function call in a future release.
 
 ## 0.3.0
- - Changes from @sempervictus to expose internal values again
+ - Extensive work by @sempervictus to expose the segments/fields as collections (which I hadn't got back to after the re-write to slices.)
 
 ## 0.2.0
-- Re-write to avoid excessive string cloning by operating on slices of the source HL7
+-  Re-Write to not expose cloned/copied vecs of vecs everywhere.  We have all the data in a single string slice to begin with so lets return slices from that.
 
 ## 0.1.0
 - Initial string.clone() heavy library, nothing to see here...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-hl7"
-version = "0.4.0"
-authors = ["wokket <wokket@gmail.com>"]
+version = "0.5.0-pre"
+authors = ["wokket <github@wokket.com>"]
 edition = "2018"
 description = "HL7 Parser and object builder? query'er? - experimental only at any rate"
 license = "MIT OR Apache-2.0"

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -11,7 +11,7 @@ fn message_parse(c: &mut Criterion) {
     c.bench_function("oru parse", |b| {
        
         b.iter(|| {
-            let m = Message::try_from(get_sample_message()).unwrap();
+            let m = Message::try_from(msg).unwrap();
             let seg = m.segments.first();
 
             if let Some(Segment::MSH(msh)) = seg {

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -26,7 +26,6 @@ fn get_segments_by_name(c: &mut Criterion) {
 }
 
 fn get_msh_and_read_field(c: &mut Criterion) {
-
     c.bench_function("Read Field from MSH (variable)", |b| {
         let m = Message::try_from(get_sample_message()).unwrap();
 
@@ -35,14 +34,13 @@ fn get_msh_and_read_field(c: &mut Criterion) {
 
             if let Some(Segment::MSH(msh)) = seg {
                 let _app = msh.msh_3_sending_application.as_ref().unwrap(); // direct variable access
-                //println!("{}", _app.value());
+                                                                            //println!("{}", _app.value());
             }
         })
     });
 }
 
 fn get_pid_and_read_field_via_vec(c: &mut Criterion) {
-
     c.bench_function("Read Field from PID (lookup)", |b| {
         let m = Message::try_from(get_sample_message()).unwrap();
 
@@ -58,18 +56,22 @@ fn get_pid_and_read_field_via_vec(c: &mut Criterion) {
 }
 
 fn get_pid_and_read_field_via_query(c: &mut Criterion) {
-
     c.bench_function("Read Field from PID (query)", |b| {
         let m = Message::try_from(get_sample_message()).unwrap();
 
         b.iter(|| {
             let _val = m.query("PID.F3"); // query via Message
             assert_eq!(_val, "555-44-4444"); // lookup from vec
-
         })
     });
 }
 
-
-criterion_group!(benches, message_parse, get_segments_by_name, get_msh_and_read_field, get_pid_and_read_field_via_vec, get_pid_and_read_field_via_query);
+criterion_group!(
+    benches,
+    message_parse,
+    get_segments_by_name,
+    get_msh_and_read_field,
+    get_pid_and_read_field_via_vec,
+    get_pid_and_read_field_via_query
+);
 criterion_main!(benches);

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -11,7 +11,7 @@ fn message_parse(c: &mut Criterion) {
     c.bench_function("oru parse", |b| {
        
         b.iter(|| {
-            let m = Message::try_from(msg).unwrap();
+            let m = Message::try_from(get_sample_message()).unwrap();
             let seg = m.segments.first();
 
             if let Some(Segment::MSH(msh)) = seg {

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -1,15 +1,13 @@
-use std::convert::TryFrom;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rusthl7::{message::*, segments::Segment};
+use std::convert::TryFrom;
 
 fn get_sample_message() -> &'static str {
     "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F"
 }
 
 fn message_parse(c: &mut Criterion) {
-    
     c.bench_function("oru parse", |b| {
-       
         b.iter(|| {
             let m = Message::try_from(get_sample_message()).unwrap();
             let seg = m.segments.first();

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -1,6 +1,6 @@
-use std::convert::TryFrom;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rusthl7::{message::*, segments::Segment};
+use std::convert::TryFrom;
 
 fn get_sample_message() -> &'static str {
     "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F"
@@ -8,7 +8,6 @@ fn get_sample_message() -> &'static str {
 
 fn message_parse(c: &mut Criterion) {
     c.bench_function("oru parse", |b| {
-       
         b.iter(|| {
             let m = Message::try_from(get_sample_message()).unwrap();
             let seg = m.segments.first();

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -1,6 +1,6 @@
+use std::convert::TryFrom;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rusthl7::{message::*, segments::Segment};
-use std::convert::TryFrom;
 
 fn get_sample_message() -> &'static str {
     "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F"
@@ -8,6 +8,7 @@ fn get_sample_message() -> &'static str {
 
 fn message_parse(c: &mut Criterion) {
     c.bench_function("oru parse", |b| {
+       
         b.iter(|| {
             let m = Message::try_from(get_sample_message()).unwrap();
             let seg = m.segments.first();

--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -7,18 +7,69 @@ fn get_sample_message() -> &'static str {
 }
 
 fn message_parse(c: &mut Criterion) {
-    c.bench_function("oru parse", |b| {
+    c.bench_function("ORU parse", |b| {
         b.iter(|| {
-            let m = Message::try_from(get_sample_message()).unwrap();
+            let _ = Message::try_from(get_sample_message()).unwrap();
+        })
+    });
+}
+
+fn get_segments_by_name(c: &mut Criterion) {
+    c.bench_function("Get Segment By Name", |b| {
+        let m = Message::try_from(get_sample_message()).unwrap();
+
+        b.iter(|| {
+            let _segs = m.generic_segments_by_name("OBR").unwrap();
+            //assert!(segs.len() == 1);
+        })
+    });
+}
+
+fn get_msh_and_read_field(c: &mut Criterion) {
+
+    c.bench_function("Read Field from MSH (variable)", |b| {
+        let m = Message::try_from(get_sample_message()).unwrap();
+
+        b.iter(|| {
             let seg = m.segments.first();
 
             if let Some(Segment::MSH(msh)) = seg {
-                let _app = msh.msh_3_sending_application.as_ref().unwrap();
+                let _app = msh.msh_3_sending_application.as_ref().unwrap(); // direct variable access
                 //println!("{}", _app.value());
             }
         })
     });
 }
 
-criterion_group!(benches, message_parse);
+fn get_pid_and_read_field_via_vec(c: &mut Criterion) {
+
+    c.bench_function("Read Field from PID (lookup)", |b| {
+        let m = Message::try_from(get_sample_message()).unwrap();
+
+        b.iter(|| {
+            let seg = &m.segments[1];
+
+            if let Segment::Generic(pid) = seg {
+                let _field = pid[3];
+                assert_eq!(_field, "555-44-4444"); // lookup from vec
+            }
+        })
+    });
+}
+
+fn get_pid_and_read_field_via_query(c: &mut Criterion) {
+
+    c.bench_function("Read Field from PID (query)", |b| {
+        let m = Message::try_from(get_sample_message()).unwrap();
+
+        b.iter(|| {
+            let _val = m.query("PID.F3"); // query via Message
+            assert_eq!(_val, "555-44-4444"); // lookup from vec
+
+        })
+    });
+}
+
+
+criterion_group!(benches, message_parse, get_segments_by_name, get_msh_and_read_field, get_pid_and_read_field_via_vec, get_pid_and_read_field_via_query);
 criterion_main!(benches);

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -1,7 +1,7 @@
-use super::separators::Separators;
-use super::*;
 use std::fmt::Display;
 use std::ops::Index;
+use super::separators::Separators;
+use super::*;
 
 /// Represents a single field inside the HL7.  Note that fields can include repeats, components and sub-components.
 /// See [the spec](http://www.hl7.eu/HL7v2x/v251/std251/ch02.html#Heading13) for more info
@@ -105,6 +105,7 @@ impl<'a> Field<'a> {
         &self.query(idx.as_str())
     }
 }
+
 
 impl<'a> Display for Field<'a> {
     /// Required for to_string() and other formatter consumers
@@ -294,7 +295,7 @@ mod tests {
         let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
         let idx0 = String::from("R2");
         let oob = "R2.C3";
-        assert_eq!(f.query_by_string(idx0), "yyy&zzz");
+        assert_eq!(f.query_by_string(idx0.clone()), "yyy&zzz");
         assert_eq!(f.query("R2.C2"), "zzz");
         assert_eq!(f.query(oob), "");
     }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -1,9 +1,12 @@
+use std::fmt::Display;
+use std::ops::Index;
 use super::separators::Separators;
 use super::*;
+
+
 /// Represents a single field inside the HL7.  Note that fields can include repeats, components and sub-components.
 /// See [the spec](http://www.hl7.eu/HL7v2x/v251/std251/ch02.html#Heading13) for more info
 #[derive(Debug, PartialEq)]
-
 pub struct Field<'a> {
     pub source: &'a str,
     pub delims: Separators,
@@ -29,7 +32,7 @@ impl<'a> Field<'a> {
         Ok(field)
     }
 
-    /// Used to hide the removal of NoneError for #2...  If passed `Some()` value it retursn a field with that value.  If passed `None() it returns an `Err(Hl7ParseError::MissingRequiredValue{})`
+    /// Used to hide the removal of NoneError for #2...  If passed `Some()` value it returns a field with that value.  If passed `None() it returns an `Err(Hl7ParseError::MissingRequiredValue{})`
     pub fn parse_mandatory(
         input: Option<&'a str>,
         delims: &Separators,
@@ -62,9 +65,49 @@ impl<'a> Field<'a> {
     pub fn as_str(&self) -> &'a str {
         self.source
     }
+
+    /// Access string reference of a Field component by String index
+    /// Adjust the index by one as medical people do not count from zero
+    pub fn query(&self, sidx: &str) -> &'a str {
+        let parts = sidx.split('.').collect::<Vec<&str>>();
+
+        if parts.len() == 1 {
+            let stringnums = parts[0]
+                .chars()
+                .filter(|c| c.is_digit(10))
+                .collect::<String>();
+            let idx: usize = stringnums.parse().unwrap();
+
+            &self[idx - 1]
+        } else if parts.len() == 2 {
+            let stringnums = parts[0]
+                .chars()
+                .filter(|c| c.is_digit(10))
+                .collect::<String>();
+
+            let idx0: usize = stringnums.parse().unwrap();
+
+            let stringnums = parts[1]
+                .chars()
+                .filter(|c| c.is_digit(10))
+                .collect::<String>();
+
+            let idx1: usize = stringnums.parse().unwrap();
+
+            &self[(idx0 - 1, idx1 - 1)]
+        } else {
+            ""
+        }
+    }
+
+    /// Access Segment, Field, or sub-field string references by string index
+    pub fn query_by_string(&self, idx: String) -> &'a str {
+        &self.query(idx.as_str())
+    }
+
 }
 
-use std::fmt::Display;
+
 impl<'a> Display for Field<'a> {
     /// Required for to_string() and other formatter consumers
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -72,7 +115,7 @@ impl<'a> Display for Field<'a> {
     }
 }
 
-use std::ops::Index;
+
 impl<'a> Clone for Field<'a> {
     /// Creates a new Message object using a clone of the original's source
     fn clone(&self) -> Self {
@@ -250,10 +293,9 @@ mod tests {
         let d = Separators::default();
         let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
         let idx0 = String::from("R2");
-        let idx1 = String::from("R2.C2");
-        let oob = String::from("R2.C3");
-        assert_eq!(f[idx0.clone()], "yyy&zzz");
-        assert_eq!(f[idx1], "zzz");
-        assert_eq!(f[oob], "");
+        let oob = "R2.C3";
+        assert_eq!(f.query_by_string(idx0.clone()), "yyy&zzz");
+        assert_eq!(f.query("R2.C2"), "zzz");
+        assert_eq!(f.query(oob), "");
     }
 }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -1,8 +1,7 @@
-use std::fmt::Display;
-use std::ops::Index;
 use super::separators::Separators;
 use super::*;
-
+use std::fmt::Display;
+use std::ops::Index;
 
 /// Represents a single field inside the HL7.  Note that fields can include repeats, components and sub-components.
 /// See [the spec](http://www.hl7.eu/HL7v2x/v251/std251/ch02.html#Heading13) for more info
@@ -29,6 +28,7 @@ impl<'a> Field<'a> {
             components,
             subcomponents,
         };
+
         Ok(field)
     }
 
@@ -104,9 +104,7 @@ impl<'a> Field<'a> {
     pub fn query_by_string(&self, idx: String) -> &'a str {
         &self.query(idx.as_str())
     }
-
 }
-
 
 impl<'a> Display for Field<'a> {
     /// Required for to_string() and other formatter consumers
@@ -114,7 +112,6 @@ impl<'a> Display for Field<'a> {
         write!(f, "{}", self.source)
     }
 }
-
 
 impl<'a> Clone for Field<'a> {
     /// Creates a new Message object using a clone of the original's source
@@ -128,8 +125,9 @@ impl<'a> Index<usize> for Field<'a> {
     type Output = &'a str;
     fn index(&self, idx: usize) -> &Self::Output {
         if idx > self.components.len() - 1 {
-            return &"";
+            return &""; //TODO: We're returning &&str here which doesn't seem right?!?
         }
+
         &self.components[idx]
     }
 }
@@ -139,8 +137,9 @@ impl<'a> Index<(usize, usize)> for Field<'a> {
     type Output = &'a str;
     fn index(&self, idx: (usize, usize)) -> &Self::Output {
         if idx.0 > self.components.len() - 1 || idx.1 > self.subcomponents[idx.0].len() - 1 {
-            return &"";
+            return &""; //TODO: We're returning &&str here which doesn't seem right?!?
         }
+
         &self.subcomponents[idx.0][idx.1]
     }
 }
@@ -256,6 +255,7 @@ mod tests {
     fn test_parse_components() {
         let d = Separators::default();
         let f = Field::parse_mandatory(Some("xxx^yyy"), &d).unwrap();
+
         assert_eq!(f.components.len(), 2)
     }
 
@@ -294,7 +294,7 @@ mod tests {
         let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
         let idx0 = String::from("R2");
         let oob = "R2.C3";
-        assert_eq!(f.query_by_string(idx0.clone()), "yyy&zzz");
+        assert_eq!(f.query_by_string(idx0), "yyy&zzz");
         assert_eq!(f.query("R2.C2"), "zzz");
         assert_eq!(f.query(oob), "");
     }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -15,7 +15,8 @@ pub struct Field<'a> {
 
 impl<'a> Field<'a> {
     /// Convert the given line of text into a field.
-    pub fn parse(input: &'a str, delims: &Separators) -> Result<Field<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<Field<'a>, Hl7ParseError> {
+        let input = input.into();
         let components = input.split(delims.component).collect::<Vec<&'a str>>();
         let subcomponents = components
             .iter()
@@ -57,18 +58,23 @@ impl<'a> Field<'a> {
     }
 
     /// Compatibility method to get the underlying value of this field.
+    #[inline]
     pub fn value(&self) -> &'a str {
         self.source
     }
 
     /// Export value to str
+    #[inline]
     pub fn as_str(&self) -> &'a str {
         self.source
     }
 
     /// Access string reference of a Field component by String index
     /// Adjust the index by one as medical people do not count from zero
-    pub fn query(&self, sidx: &str) -> &'a str {
+    pub fn query<'b, S>(&self, sidx: S) -> &'a str
+        where S: Into<&'b str> {
+
+        let sidx = sidx.into();
         let parts = sidx.split('.').collect::<Vec<&str>>();
 
         if parts.len() == 1 {
@@ -98,11 +104,6 @@ impl<'a> Field<'a> {
         } else {
             ""
         }
-    }
-
-    /// Access Segment, Field, or sub-field string references by string index
-    pub fn query_by_string(&self, idx: String) -> &'a str {
-        &self.query(idx.as_str())
     }
 }
 
@@ -294,7 +295,7 @@ mod tests {
         let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
         let idx0 = String::from("R2");
         let oob = "R2.C3";
-        assert_eq!(f.query_by_string(idx0), "yyy&zzz");
+        assert_eq!(f.query(&*idx0), "yyy&zzz");
         assert_eq!(f.query("R2.C2"), "zzz");
         assert_eq!(f.query(oob), "");
     }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
-use std::ops::Index;
 use super::separators::Separators;
 use super::*;
+use std::fmt::Display;
+use std::ops::Index;
 
 /// Represents a single field inside the HL7.  Note that fields can include repeats, components and sub-components.
 /// See [the spec](http://www.hl7.eu/HL7v2x/v251/std251/ch02.html#Heading13) for more info
@@ -105,7 +105,6 @@ impl<'a> Field<'a> {
         &self.query(idx.as_str())
     }
 }
-
 
 impl<'a> Display for Field<'a> {
     /// Required for to_string() and other formatter consumers
@@ -295,7 +294,7 @@ mod tests {
         let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
         let idx0 = String::from("R2");
         let oob = "R2.C3";
-        assert_eq!(f.query_by_string(idx0.clone()), "yyy&zzz");
+        assert_eq!(f.query_by_string(idx0), "yyy&zzz");
         assert_eq!(f.query("R2.C2"), "zzz");
         assert_eq!(f.query(oob), "");
     }

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -15,7 +15,10 @@ pub struct Field<'a> {
 
 impl<'a> Field<'a> {
     /// Convert the given line of text into a field.
-    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<Field<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(
+        input: S,
+        delims: &Separators,
+    ) -> Result<Field<'a>, Hl7ParseError> {
         let input = input.into();
         let components = input.split(delims.component).collect::<Vec<&'a str>>();
         let subcomponents = components
@@ -72,8 +75,9 @@ impl<'a> Field<'a> {
     /// Access string reference of a Field component by String index
     /// Adjust the index by one as medical people do not count from zero
     pub fn query<'b, S>(&self, sidx: S) -> &'a str
-        where S: Into<&'b str> {
-
+    where
+        S: Into<&'b str>,
+    {
         let sidx = sidx.into();
         let parts = sidx.split('.').collect::<Vec<&str>>();
 
@@ -84,7 +88,7 @@ impl<'a> Field<'a> {
                 .collect::<String>();
             let idx: usize = stringnums.parse().unwrap();
 
-            &self[idx - 1]
+            self[idx - 1]
         } else if parts.len() == 2 {
             let stringnums = parts[0]
                 .chars()
@@ -100,7 +104,7 @@ impl<'a> Field<'a> {
 
             let idx1: usize = stringnums.parse().unwrap();
 
-            &self[(idx0 - 1, idx1 - 1)]
+            self[(idx0 - 1, idx1 - 1)]
         } else {
             ""
         }
@@ -148,7 +152,7 @@ impl<'a> Index<(usize, usize)> for Field<'a> {
 /// DEPRECATED. Access string reference of a Field component by String index
 /// Adjust the index by one as medical people do not count from zero
 #[allow(useless_deprecated)]
-#[deprecated(note="This will be removed in a future version")]
+#[deprecated(note = "This will be removed in a future version")]
 impl<'a> Index<String> for Field<'a> {
     type Output = &'a str;
     fn index(&self, sidx: String) -> &Self::Output {
@@ -189,7 +193,7 @@ impl<'a> Index<&str> for Field<'a> {
 
     /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
     #[allow(useless_deprecated)]
-    #[deprecated(note="This will be removed in a future version")]
+    #[deprecated(note = "This will be removed in a future version")]
     fn index(&self, idx: &str) -> &Self::Output {
         &self[String::from(idx)]
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -102,15 +102,14 @@ impl<'a> Message<'a> {
             .segments
             .iter()
             .position(|r| &r.as_str()[..seg_name.len()] == seg_name);
-
-        match seg_index {
-            //TODO: What is this doing...
+        
+        match seg_index { //TODO: What is this doing...
             Some(_) => {}
             None => return &"",
         }
 
         let seg = &self.segments[seg_index.unwrap()];
-
+        
         // Return the appropriate source reference
         match seg {
             // Short circuit for now
@@ -127,10 +126,8 @@ impl<'a> Message<'a> {
         }
     }
 
-    ///Access segment, field, or sub-field string references by passing a query string in dot notation.
-    ///See [`Self::query()`] for more information.
+    /// Access Segment, Field, or sub-field string references by string index
     pub fn query_by_string(&self, idx: String) -> &'a str {
-        //TODO: Determine if we actually need this function... in what scenario are we passing a String in here rather an &str?
         self.query(idx.as_str())
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -325,6 +325,7 @@ mod tests {
         let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment^sub&segment";
         let msg = Message::try_from(hl7)?;
         assert_eq!(msg.query("OBR.F1.R2.C1"), "sub");
+        assert_eq!(msg[String::from("OBR.F1.R2.C1")], "sub");
         Ok(())
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -74,7 +74,19 @@ impl<'a> Message<'a> {
         Ok(vecs)
     }
 
-    /// Export source to str
+    /// Returns the source string slice used to create this Message initially.
+    /// ## Example:
+    /// ```
+    /// # use rusthl7::Hl7ParseError;
+    /// # use rusthl7::message::Message;
+    /// # use std::convert::TryFrom;
+    /// # fn main() -> Result<(), Hl7ParseError> {
+    /// let source = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
+    /// let m = Message::try_from(source)?;
+    /// assert_eq!(source, m.as_str());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn as_str(&self) -> &'a str {
         self.source
     }
@@ -90,14 +102,15 @@ impl<'a> Message<'a> {
             .segments
             .iter()
             .position(|r| &r.as_str()[..seg_name.len()] == seg_name);
-        
-        match seg_index { //TODO: What is this doing...
+
+        match seg_index {
+            //TODO: What is this doing...
             Some(_) => {}
             None => return &"",
         }
 
         let seg = &self.segments[seg_index.unwrap()];
-        
+
         // Return the appropriate source reference
         match seg {
             // Short circuit for now
@@ -114,7 +127,8 @@ impl<'a> Message<'a> {
         }
     }
 
-    /// Access Segment, Field, or sub-field string references by string index
+    ///Access segment, field, or sub-field string references by passing a query string in dot notation.
+    ///See [`Self::query()`] for more information.
     pub fn query_by_string(&self, idx: String) -> &'a str {
         //TODO: Determine if we actually need this function... in what scenario are we passing a String in here rather an &str?
         self.query(idx.as_str())
@@ -151,6 +165,17 @@ impl<'a> Display for Message<'a> {
 
 impl<'a> Clone for Message<'a> {
     /// Creates a new cloned Message object referencing the same source slice as the original.
+    /// ## Example:
+    /// ```
+    /// # use rusthl7::Hl7ParseError;
+    /// # use rusthl7::message::Message;
+    /// # use std::convert::TryFrom;
+    /// # fn main() -> Result<(), Hl7ParseError> {
+    /// let m = Message::try_from("MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4")?;
+    /// let cloned = m.clone(); // this object is looking at the same string slice as m
+    /// # Ok(())
+    /// # }
+    /// ```
     fn clone(&self) -> Self {
         Message::try_from(self.source).unwrap()
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -93,9 +93,10 @@ impl<'a> Message<'a> {
     }
 
     /// Access Segment, Field, or sub-field string references by string index
-    pub fn query<'b, S>(&self, idx: S) -> &'a str 
-        where S: Into<&'b str> {
-
+    pub fn query<'b, S>(&self, idx: S) -> &'a str
+    where
+        S: Into<&'b str>,
+    {
         let idx = idx.into();
 
         // Parse index elements
@@ -111,7 +112,7 @@ impl<'a> Message<'a> {
         match seg_index {
             //TODO: What is this doing...
             Some(_) => {}
-            None => return &"",
+            None => return "",
         }
 
         let seg = &self.segments[seg_index.unwrap()];
@@ -119,19 +120,18 @@ impl<'a> Message<'a> {
         // Return the appropriate source reference
         match seg {
             // Short circuit for now
-            Segment::MSH(m) => &m.source,
+            Segment::MSH(m) => m.source,
             // Parse out slice depth
             Segment::Generic(g) => {
                 if indices.len() < 2 {
-                    &g.source
+                    g.source
                 } else {
                     let query = indices[1..].join(".");
-                    &g.query(&*query)
+                    g.query(&*query)
                 }
             }
         }
     }
-
 }
 
 impl<'a> TryFrom<&'a str> for Message<'a> {
@@ -204,7 +204,7 @@ impl<'a> Index<String> for Message<'a> {
 
     /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
     #[allow(useless_deprecated)]
-    #[deprecated(note="This will be removed in a future version")]
+    #[deprecated(note = "This will be removed in a future version")]
     fn index(&self, idx: String) -> &Self::Output {
         // Parse index elements
         let indices: Vec<&str> = idx.split('.').collect();
@@ -240,7 +240,7 @@ impl<'a> Index<&str> for Message<'a> {
 
     /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
     #[allow(useless_deprecated)]
-    #[deprecated(note="This will be removed in a future version")]
+    #[deprecated(note = "This will be removed in a future version")]
     fn index(&self, idx: &str) -> &Self::Output {
         &self[String::from(idx)]
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -102,14 +102,15 @@ impl<'a> Message<'a> {
             .segments
             .iter()
             .position(|r| &r.as_str()[..seg_name.len()] == seg_name);
-        
-        match seg_index { //TODO: What is this doing...
+
+        match seg_index {
+            //TODO: What is this doing...
             Some(_) => {}
             None => return &"",
         }
 
         let seg = &self.segments[seg_index.unwrap()];
-        
+
         // Return the appropriate source reference
         match seg {
             // Short circuit for now
@@ -126,7 +127,8 @@ impl<'a> Message<'a> {
         }
     }
 
-    /// Access Segment, Field, or sub-field string references by string index
+    ///Access segment, field, or sub-field string references by passing a query string in dot notation.
+    ///See [`Self::query()`] for more information.
     pub fn query_by_string(&self, idx: String) -> &'a str {
         //TODO: Determine if we actually need this function... in what scenario are we passing a String in here rather an &str?
         self.query(idx.as_str())

--- a/src/message.rs
+++ b/src/message.rs
@@ -116,6 +116,7 @@ impl<'a> Message<'a> {
 
     /// Access Segment, Field, or sub-field string references by string index
     pub fn query_by_string(&self, idx: String) -> &'a str {
+        //TODO: Determine if we actually need this function... in what scenario are we passing a String in here rather an &str?
         self.query(idx.as_str())
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -128,6 +128,7 @@ impl<'a> Message<'a> {
 
     /// Access Segment, Field, or sub-field string references by string index
     pub fn query_by_string(&self, idx: String) -> &'a str {
+        //TODO: Determine if we actually need this function... in what scenario are we passing a String in here rather an &str?
         self.query(idx.as_str())
     }
 }

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -1,6 +1,6 @@
+use super::{fields::Field, separators::Separators, Hl7ParseError};
 use std::fmt::Display;
 use std::ops::Index;
-use super::{Hl7ParseError, fields::Field, separators::Separators};
 
 /// A generic bag o' fields, representing an arbitrary segment.
 #[derive(Debug, PartialEq, Clone)]
@@ -58,9 +58,8 @@ impl<'a> GenericSegment<'a> {
                 let idx: usize = stringnum.parse().unwrap();
                 let field = &self.fields[idx];
                 let query = sections[1..].join(".");
-                
-                field.query_by_string(query)
 
+                field.query_by_string(query)
             }
         }
     }
@@ -174,9 +173,7 @@ mod tests {
                 x.query_by_string(String::from("F1")),
                 x.query_by_string(String::from("F1.R2")),
                 x.query_by_string(String::from("F1.R2.C1")),
-                String::from(x.query("F10"))
-                    + x.query("F1.R10")
-                    + x.query("F1.R2.C10"),
+                String::from(x.query("F10")) + x.query("F1.R10") + x.query("F1.R2.C10"),
             ),
             _ => ("", "", "", String::from("")),
         };

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -12,7 +12,10 @@ pub struct GenericSegment<'a> {
 
 impl<'a> GenericSegment<'a> {
     /// Convert the given line of text into a GenericSegment.
-    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<GenericSegment<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(
+        input: S,
+        delims: &Separators,
+    ) -> Result<GenericSegment<'a>, Hl7ParseError> {
         let input = input.into();
 
         let fields: Result<Vec<Field<'a>>, Hl7ParseError> = input
@@ -37,8 +40,9 @@ impl<'a> GenericSegment<'a> {
 
     /// Access Field as string reference
     pub fn query<'b, S>(&self, fidx: S) -> &'a str
-        where S: Into<&'b str> {
-
+    where
+        S: Into<&'b str>,
+    {
         let fidx = fidx.into();
         let sections = fidx.split('.').collect::<Vec<&str>>();
 
@@ -49,7 +53,7 @@ impl<'a> GenericSegment<'a> {
                     .filter(|c| c.is_digit(10))
                     .collect::<String>();
                 let idx: usize = stringnum.parse().unwrap();
-                &self[idx]
+                self[idx]
             }
             _ => {
                 let stringnum = sections[0]
@@ -140,7 +144,7 @@ impl<'a> Index<&str> for GenericSegment<'a> {
 
     /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
     #[allow(useless_deprecated)]
-    #[deprecated(note="This will be removed in a future version")]
+    #[deprecated(note = "This will be removed in a future version")]
     fn index(&self, idx: &str) -> &Self::Output {
         &self[String::from(idx)]
     }
@@ -171,8 +175,8 @@ mod tests {
         let msg = Message::try_from(hl7).unwrap();
         let (f, c, s, oob) = match &msg.segments[1] {
             Segment::Generic(x) => (
-                x.query("F1"), //&str
-                x.query("F1.R2"), // &str
+                x.query("F1"),                       //&str
+                x.query("F1.R2"),                    // &str
                 x.query(&*String::from("F1.R2.C1")), //String
                 String::from(x.query("F10")) + x.query("F1.R10") + x.query("F1.R2.C10"),
             ),

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -1,6 +1,6 @@
+use super::{fields::Field, separators::Separators, Hl7ParseError};
 use std::fmt::Display;
 use std::ops::Index;
-use super::{Hl7ParseError, fields::Field, separators::Separators};
 
 /// A generic bag o' fields, representing an arbitrary segment.
 #[derive(Debug, PartialEq, Clone)]
@@ -58,9 +58,8 @@ impl<'a> GenericSegment<'a> {
                 let idx: usize = stringnum.parse().unwrap();
                 let field = &self.fields[idx];
                 let query = sections[1..].join(".");
-                
-                field.query_by_string(query)
 
+                field.query_by_string(query)
             }
         }
     }
@@ -72,7 +71,6 @@ impl<'a> Display for GenericSegment<'a> {
         write!(f, "{}", self.source)
     }
 }
-
 
 impl<'a> Index<usize> for GenericSegment<'a> {
     type Output = &'a str;
@@ -174,9 +172,7 @@ mod tests {
                 x.query_by_string(String::from("F1")),
                 x.query_by_string(String::from("F1.R2")),
                 x.query_by_string(String::from("F1.R2.C1")),
-                String::from(x.query("F10"))
-                    + x.query("F1.R10")
-                    + x.query("F1.R2.C10"),
+                String::from(x.query("F10")) + x.query("F1.R10") + x.query("F1.R2.C10"),
             ),
             _ => ("", "", "", String::from("")),
         };

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -1,6 +1,6 @@
-use super::{fields::Field, separators::Separators, Hl7ParseError};
 use std::fmt::Display;
 use std::ops::Index;
+use super::{Hl7ParseError, fields::Field, separators::Separators};
 
 /// A generic bag o' fields, representing an arbitrary segment.
 #[derive(Debug, PartialEq, Clone)]
@@ -58,8 +58,9 @@ impl<'a> GenericSegment<'a> {
                 let idx: usize = stringnum.parse().unwrap();
                 let field = &self.fields[idx];
                 let query = sections[1..].join(".");
-
+                
                 field.query_by_string(query)
+
             }
         }
     }
@@ -107,6 +108,7 @@ impl<'a> Index<(usize, usize, usize)> for GenericSegment<'a> {
         &self.fields[fidx.0][(fidx.1, fidx.2)]
     }
 }
+
 impl<'a> Index<String> for GenericSegment<'a> {
     type Output = &'a str;
     /// Access Field as string reference

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -31,6 +31,34 @@ impl<'a> GenericSegment<'a> {
     pub fn as_str(&self) -> &'a str {
         self.source
     }
+
+    /// Access Segment, Field, or sub-field string references by string index
+    pub fn query(&self, idx: &str) -> &'a str {
+        self.query_by_string(String::from(idx))
+    }
+
+    /// Access Field as string reference
+    pub fn query_by_string(&self, fidx: String) -> &'a str {
+        let sections = fidx.split('.').collect::<Vec<&str>>();
+        match sections.len() {
+            1 => {
+                let stringnum = sections[0]
+                    .chars()
+                    .filter(|c| c.is_digit(10))
+                    .collect::<String>();
+                let idx: usize = stringnum.parse().unwrap();
+                &self[idx]
+            }
+            _ => {
+                let stringnum = sections[0]
+                    .chars()
+                    .filter(|c| c.is_digit(10))
+                    .collect::<String>();
+                let idx: usize = stringnum.parse().unwrap();
+                &self.fields[idx][sections[1..].join(".")]
+            }
+        }
+    }
 }
 
 use std::fmt::Display;
@@ -139,12 +167,12 @@ mod tests {
         let msg = Message::try_from(hl7).unwrap();
         let (f, c, s, oob) = match &msg.segments[1] {
             Segment::Generic(x) => (
-                x[String::from("F1")],
-                x[String::from("F1.R2")],
-                x[String::from("F1.R2.C1")],
-                String::from(x[String::from("F10")])
-                    + x[String::from("F1.R10")]
-                    + x[String::from("F1.R2.C10")],
+                x.query_by_string(String::from("F1")),
+                x.query_by_string(String::from("F1.R2")),
+                x.query_by_string(String::from("F1.R2.C1")),
+                String::from(x.query("F10"))
+                    + x.query("F1.R10")
+                    + x.query("F1.R2.C10"),
             ),
             _ => ("", "", "", String::from("")),
         };

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -172,7 +172,9 @@ mod tests {
                 x.query_by_string(String::from("F1")),
                 x.query_by_string(String::from("F1.R2")),
                 x.query_by_string(String::from("F1.R2.C1")),
-                String::from(x.query("F10")) + x.query("F1.R10") + x.query("F1.R2.C10"),
+                String::from(x.query("F10"))
+                    + x.query("F1.R10")
+                    + x.query("F1.R2.C10"),
             ),
             _ => ("", "", "", String::from("")),
         };

--- a/src/segments/generic.rs
+++ b/src/segments/generic.rs
@@ -12,7 +12,9 @@ pub struct GenericSegment<'a> {
 
 impl<'a> GenericSegment<'a> {
     /// Convert the given line of text into a GenericSegment.
-    pub fn parse(input: &'a str, delims: &Separators) -> Result<GenericSegment<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<GenericSegment<'a>, Hl7ParseError> {
+        let input = input.into();
+
         let fields: Result<Vec<Field<'a>>, Hl7ParseError> = input
             .split(delims.field)
             .map(|line| Field::parse(line, delims))
@@ -28,17 +30,16 @@ impl<'a> GenericSegment<'a> {
     }
 
     /// Export source to str
+    #[inline]
     pub fn as_str(&self) -> &'a str {
         self.source
     }
 
-    /// Access Segment, Field, or sub-field string references by string index
-    pub fn query_by_string(&self, idx: String) -> &'a str {
-        self.query(idx.as_str())
-    }
-
     /// Access Field as string reference
-    pub fn query(&self, fidx: &str) -> &'a str {
+    pub fn query<'b, S>(&self, fidx: S) -> &'a str
+        where S: Into<&'b str> {
+
+        let fidx = fidx.into();
         let sections = fidx.split('.').collect::<Vec<&str>>();
 
         match sections.len() {
@@ -59,7 +60,7 @@ impl<'a> GenericSegment<'a> {
                 let field = &self.fields[idx];
                 let query = sections[1..].join(".");
 
-                field.query_by_string(query)
+                field.query(&*query)
             }
         }
     }
@@ -170,9 +171,9 @@ mod tests {
         let msg = Message::try_from(hl7).unwrap();
         let (f, c, s, oob) = match &msg.segments[1] {
             Segment::Generic(x) => (
-                x.query_by_string(String::from("F1")),
-                x.query_by_string(String::from("F1.R2")),
-                x.query_by_string(String::from("F1.R2.C1")),
+                x.query("F1"), //&str
+                x.query("F1.R2"), // &str
+                x.query(&*String::from("F1.R2.C1")), //String
                 String::from(x.query("F10")) + x.query("F1.R10") + x.query("F1.R2.C10"),
             ),
             _ => ("", "", "", String::from("")),

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -1,6 +1,7 @@
 pub mod generic;
 pub mod msh;
 
+use std::fmt::Display;
 use super::fields::Field;
 use super::separators::Separators;
 use super::*;
@@ -16,7 +17,9 @@ pub enum Segment<'a> {
 
 impl<'a> Segment<'a> {
     /// Convert the given line of text into a Segment.
-    pub fn parse(input: &'a str, delims: &Separators) -> Result<Segment<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<Segment<'a>, Hl7ParseError> {
+        let input = input.into();
+
         let fields: Result<Vec<Field<'a>>, Hl7ParseError> = input
             .split(delims.field)
             .map(|line| Field::parse(line, delims))
@@ -41,7 +44,6 @@ impl<'a> Segment<'a> {
     }
 }
 
-use std::fmt::Display;
 impl<'a> Display for Segment<'a> {
     /// Required for to_string() and other formatter consumers
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/segments/mod.rs
+++ b/src/segments/mod.rs
@@ -1,12 +1,12 @@
 pub mod generic;
 pub mod msh;
 
-use std::fmt::Display;
 use super::fields::Field;
 use super::separators::Separators;
 use super::*;
 use generic::GenericSegment;
 use msh::MshSegment;
+use std::fmt::Display;
 
 /// A single segment, 0x13 delimited line from a source HL7 message consisting of multiple fields.
 #[derive(Debug, PartialEq)]
@@ -17,7 +17,10 @@ pub enum Segment<'a> {
 
 impl<'a> Segment<'a> {
     /// Convert the given line of text into a Segment.
-    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<Segment<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(
+        input: S,
+        delims: &Separators,
+    ) -> Result<Segment<'a>, Hl7ParseError> {
         let input = input.into();
 
         let fields: Result<Vec<Field<'a>>, Hl7ParseError> = input

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
 use super::fields::Field;
 use super::separators::Separators;
 use super::*;
+use std::fmt::Display;
 
 /// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
 /// Given the importance of this segment for driving application behaviour, it gets the special treatment
@@ -83,7 +83,6 @@ impl<'a> MshSegment<'a> {
     }
 }
 
-
 impl<'a> Display for MshSegment<'a> {
     /// Required for to_string() and other formatter consumers
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -92,7 +91,7 @@ impl<'a> Display for MshSegment<'a> {
 }
 
 impl<'a> Clone for MshSegment<'a> {
-    /// Creates a new Message object using a clone of the original's source
+    /// Creates a new Message object using _the same source_ slice as the original.
     fn clone(&self) -> Self {
         let delims = self.msh_2_encoding_characters;
         MshSegment::parse(self.source, &delims).unwrap()

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
 use super::fields::Field;
 use super::separators::Separators;
 use super::*;
+use std::fmt::Display;
 
 /// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
 /// Given the importance of this segment for driving application behaviour, it gets the special treatment

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -1,7 +1,7 @@
+use std::fmt::Display;
 use super::fields::Field;
 use super::separators::Separators;
 use super::*;
-use std::fmt::Display;
 
 /// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
 /// Given the importance of this segment for driving application behaviour, it gets the special treatment

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -38,7 +38,10 @@ pub struct MshSegment<'a> {
 }
 
 impl<'a> MshSegment<'a> {
-    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<MshSegment<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(
+        input: S,
+        delims: &Separators,
+    ) -> Result<MshSegment<'a>, Hl7ParseError> {
         let input = input.into();
 
         let mut fields = input.split(delims.field);

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -38,7 +38,9 @@ pub struct MshSegment<'a> {
 }
 
 impl<'a> MshSegment<'a> {
-    pub fn parse(input: &'a str, delims: &Separators) -> Result<MshSegment<'a>, Hl7ParseError> {
+    pub fn parse<S: Into<&'a str>>(input: S, delims: &Separators) -> Result<MshSegment<'a>, Hl7ParseError> {
+        let input = input.into();
+
         let mut fields = input.split(delims.field);
 
         assert!(fields.next().unwrap() == "MSH");
@@ -72,6 +74,7 @@ impl<'a> MshSegment<'a> {
     }
 
     /// Export source to str
+    #[inline]
     pub fn as_str(&self) -> &'a str {
         self.source
     }

--- a/src/segments/msh.rs
+++ b/src/segments/msh.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use super::fields::Field;
 use super::separators::Separators;
 use super::*;
@@ -82,7 +83,7 @@ impl<'a> MshSegment<'a> {
     }
 }
 
-use std::fmt::Display;
+
 impl<'a> Display for MshSegment<'a> {
     /// Required for to_string() and other formatter consumers
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -143,7 +144,7 @@ mod tests {
 
         let msh = MshSegment::parse(hl7, &delims)?;
         let gen = msh.as_generic().unwrap();
-        assert_eq!("ELAB-3", gen["F3"]);
+        assert_eq!("ELAB-3", gen.query("F3"));
         Ok(())
     }
 


### PR DESCRIPTION
This PR replaces #18 now that we've pushed 0.4 straight out of master.  This PR includes adding the new `query` functions but leaves the String indexers in place for back-compat but marked as deprecated.  My current thinking is to remove the String indexers entirely in 0.6 but we can have a few smaller 0.5.x releases in the meantime..



