### PR TITLE
Move string indexing behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ description = "HL7 Parser and object builder? query'er? - experimental only at a
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/wokket/rust-hl7/"
 
+[features]
+string_index = []
+
 [lib]
 name="rusthl7"
 path="src/lib.rs"

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -149,12 +149,12 @@ impl<'a> Index<(usize, usize)> for Field<'a> {
     }
 }
 
-/// DEPRECATED. Access string reference of a Field component by String index
-/// Adjust the index by one as medical people do not count from zero
-#[allow(useless_deprecated)]
-#[deprecated(note = "This will be removed in a future version")]
+/// Access string reference of a Field component by String index
+#[cfg(feature = "string_index")]
 impl<'a> Index<String> for Field<'a> {
     type Output = &'a str;
+
+    #[cfg(feature = "string_index")]
     fn index(&self, sidx: String) -> &Self::Output {
         let parts = sidx.split('.').collect::<Vec<&str>>();
 
@@ -188,12 +188,12 @@ impl<'a> Index<String> for Field<'a> {
     }
 }
 
+#[cfg(feature = "string_index")]
 impl<'a> Index<&str> for Field<'a> {
     type Output = &'a str;
 
-    /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
-    #[allow(useless_deprecated)]
-    #[deprecated(note = "This will be removed in a future version")]
+    /// Access Segment, Field, or sub-field string references by string index
+    #[cfg(feature = "string_index")]
     fn index(&self, idx: &str) -> &Self::Output {
         &self[String::from(idx)]
     }
@@ -293,14 +293,18 @@ mod tests {
         assert_eq!(f[(1, 1)], "zzz");
     }
 
-    #[test]
-    fn test_string_index() {
-        let d = Separators::default();
-        let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
-        let idx0 = String::from("R2");
-        let oob = "R2.C3";
-        assert_eq!(f.query(&*idx0), "yyy&zzz");
-        assert_eq!(f.query("R2.C2"), "zzz");
-        assert_eq!(f.query(oob), "");
+    #[cfg(feature = "string_index")]
+    mod string_index_tests {
+        use super::*;
+        #[test]
+        fn test_string_index() {
+            let d = Separators::default();
+            let f = Field::parse_mandatory(Some("xxx^yyy&zzz"), &d).unwrap();
+            let idx0 = String::from("R2");
+            let oob = "R2.C3";
+            assert_eq!(f.query(&*idx0), "yyy&zzz");
+            assert_eq!(f.query("R2.C2"), "zzz");
+            assert_eq!(f.query(oob), "");
+        }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -205,13 +205,12 @@ impl<'a> Index<usize> for Message<'a> {
         }
     }
 }
-
+#[cfg(feature = "string_index")]
 impl<'a> Index<String> for Message<'a> {
     type Output = &'a str;
 
-    /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
-    #[allow(useless_deprecated)]
-    #[deprecated(note = "This will be removed in a future version")]
+    /// Access Segment, Field, or sub-field string references by string index
+    #[cfg(feature = "string_index")]
     fn index(&self, idx: String) -> &Self::Output {
         // Parse index elements
         let indices: Vec<&str> = idx.split('.').collect();
@@ -242,12 +241,11 @@ impl<'a> Index<String> for Message<'a> {
     }
 }
 
+#[cfg(feature = "string_index")]
 impl<'a> Index<&str> for Message<'a> {
     type Output = &'a str;
 
-    /// DEPRECATED.  Access Segment, Field, or sub-field string references by string index
-    #[allow(useless_deprecated)]
-    #[deprecated(note = "This will be removed in a future version")]
+    #[cfg(feature = "string_index")]
     fn index(&self, idx: &str) -> &Self::Output {
         &self[String::from(idx)]
     }
@@ -325,14 +323,17 @@ mod tests {
         assert_eq!(msg.to_string(), String::from(hl7));
         Ok(())
     }
-
-    #[test]
-    fn ensure_index() -> Result<(), Hl7ParseError> {
-        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment^sub&segment";
-        let msg = Message::try_from(hl7)?;
-        assert_eq!(msg.query("OBR.F1.R2.C1"), "sub");
-        assert_eq!(msg.query(&*"OBR.F1.R2.C1".to_string()), "sub"); // Test the Into param with a String
-        assert_eq!(msg[String::from("OBR.F1.R2.C1")], "sub");
-        Ok(())
+    #[cfg(feature = "string_index")]
+    mod string_index_tests {
+        use super::*;
+        #[test]
+        fn ensure_index() -> Result<(), Hl7ParseError> {
+            let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment^sub&segment";
+            let msg = Message::try_from(hl7)?;
+            assert_eq!(msg.query("OBR.F1.R2.C1"), "sub");
+            assert_eq!(msg.query(&*"OBR.F1.R2.C1".to_string()), "sub"); // Test the Into param with a String
+            assert_eq!(msg[String::from("OBR.F1.R2.C1")], "sub");
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
Instead of deprecating the `index(String)` and `index(&str)` calls
for `Message`, `GenericSegment`, and `Field`, move them behind a
feature flag for `string_index`.
The `query()` semantic has limits to how it handles called params
(attempts to convert the str idx calls to use `query()` reveal that
it converts an &str to str in the process), but the string indexing
approach isn't very Rusty in terms of idiomatic implementation
(despite bringing parity to libs in other languages). So instead of
throwing the baby out with the bath water, we can use feature flags
to allow users to choose how the library works for them.

Testing:
  Builds, passes tests, with the feature enabled and normally.