### PR TITLE
Move MshSegment out to examples/demo.rs

### DIFF
--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -25,18 +25,6 @@ fn get_segments_by_name(c: &mut Criterion) {
     });
 }
 
-fn get_msh_and_read_field(c: &mut Criterion) {
-    c.bench_function("Read Field from MSH (variable)", |b| {
-        let m = Message::try_from(get_sample_message()).unwrap();
-        let msh = m.msh().unwrap();
-
-        b.iter(|| {
-            let app =  msh.msh_3_sending_application.as_ref().unwrap(); // direct variable access
-            assert_eq!("GHH LAB", app.value());
-        })
-    });
-}
-
 fn get_pid_and_read_field_via_vec(c: &mut Criterion) {
     c.bench_function("Read Field from PID (lookup)", |b| {
         let m = Message::try_from(get_sample_message()).unwrap();
@@ -77,7 +65,6 @@ criterion_group!(
     benches,
     message_parse,
     get_segments_by_name,
-    get_msh_and_read_field,
     get_pid_and_read_field_via_vec,
     get_pid_and_read_field_via_query,
     get_pid_and_read_field_via_index
@@ -88,7 +75,6 @@ criterion_group!(
     benches,
     message_parse,
     get_segments_by_name,
-    get_msh_and_read_field,
     get_pid_and_read_field_via_vec,
     get_pid_and_read_field_via_query
 );

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,17 +2,121 @@
  A short example demonstrating one way to use this library for HL7 processing.
 */
 
-use std::{convert::TryFrom, error::Error};
-use rusthl7::{escape_sequence::EscapeSequence, message::Message};
+use rusthl7::{
+    escape_sequence::EscapeSequence, fields::Field, message::Message, separators::Separators,
+    Hl7ParseError,
+};
+use std::{convert::TryFrom, error::Error, fmt::Display};
+
+/// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
+/// Given the importance of this segment for driving application behaviour, it gets the special treatment
+/// of a fully typed segment, not just a bag of fields....
+#[derive(Debug, PartialEq)]
+pub struct MshSegment<'a> {
+    pub source: &'a str,
+    //this initial layout largely stolen from the _other_ hl7 crate: https://github.com/njaremko/hl7
+    pub msh_1_field_separator: char,
+    pub msh_2_encoding_characters: Separators,
+    pub msh_3_sending_application: Option<Field<'a>>,
+    pub msh_4_sending_facility: Option<Field<'a>>,
+    pub msh_5_receiving_application: Option<Field<'a>>,
+    pub msh_6_receiving_facility: Option<Field<'a>>,
+    pub msh_7_date_time_of_message: Field<'a>,
+    pub msh_8_security: Option<Field<'a>>,
+    pub msh_9_message_type: Field<'a>,
+    pub msh_10_message_control_id: Field<'a>,
+    pub msh_11_processing_id: Field<'a>,
+    pub msh_12_version_id: Field<'a>,
+    pub msh_13_sequence_number: Option<Field<'a>>,
+    pub msh_14_continuation_pointer: Option<Field<'a>>,
+    pub msh_15_accept_acknowledgment_type: Option<Field<'a>>,
+    pub msh_16_application_acknowledgment_type: Option<Field<'a>>,
+    pub msh_17_country_code: Option<Field<'a>>,
+    pub msh_18_character_set: Option<Field<'a>>, //TODO: repeating field
+    pub msh_19_principal_language_of_message: Option<Field<'a>>,
+    // pub msh_20_alternate_character_set_handling_scheme: Option<Field<'a>>,
+    // pub msh_21_message_profile_identifier: Option<Vec<Field<'a>>>,
+    // pub msh_22_sending_responsible_organization: Option<Field<'a>>,
+    // pub msh_23_receiving_responsible_organization: Option<Field<'a>>,
+    // pub msh_24_sending_network_address: Option<Field<'a>>,
+    // pub msh_25_receiving_network_address: Option<Field<'a>>,
+}
+
+impl<'a> MshSegment<'a> {
+    pub fn parse<S: Into<&'a str>>(
+        input: S,
+        delims: &Separators,
+    ) -> Result<MshSegment<'a>, Hl7ParseError> {
+        let input = input.into();
+
+        let mut fields = input.split(delims.field);
+
+        assert!(fields.next().unwrap() == "MSH");
+
+        let _ = fields.next(); //consume the delimiter chars
+
+        let msh = MshSegment {
+            source: input,
+            msh_1_field_separator: delims.field,
+            msh_2_encoding_characters: delims.to_owned(),
+            msh_3_sending_application: Field::parse_optional(fields.next(), delims)?,
+            msh_4_sending_facility: Field::parse_optional(fields.next(), delims)?,
+            msh_5_receiving_application: Field::parse_optional(fields.next(), delims)?,
+            msh_6_receiving_facility: Field::parse_optional(fields.next(), delims)?,
+            msh_7_date_time_of_message: Field::parse_mandatory(fields.next(), delims)?,
+            msh_8_security: Field::parse_optional(fields.next(), delims)?,
+            msh_9_message_type: Field::parse_mandatory(fields.next(), delims)?,
+            msh_10_message_control_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_11_processing_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_12_version_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_13_sequence_number: Field::parse_optional(fields.next(), delims)?,
+            msh_14_continuation_pointer: Field::parse_optional(fields.next(), delims)?,
+            msh_15_accept_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
+            msh_16_application_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
+            msh_17_country_code: Field::parse_optional(fields.next(), delims)?,
+            msh_18_character_set: Field::parse_optional(fields.next(), delims)?,
+            msh_19_principal_language_of_message: Field::parse_optional(fields.next(), delims)?,
+        };
+
+        Ok(msh)
+    }
+}
+/// Common formatter trait implementation for the strongly-typed segment
+impl<'a> Display for MshSegment<'a> {
+    /// Required for to_string() and other formatter consumers
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.source)
+    }
+}
+/// Common clone trait implementation for the strongly-typed segment
+impl<'a> Clone for MshSegment<'a> {
+    /// Creates a new Message object using _the same source_ slice as the original.
+    fn clone(&self) -> Self {
+        let delims = self.msh_2_encoding_characters;
+        MshSegment::parse(self.source, &delims).unwrap()
+    }
+}
+
+/// Extracts header element for external use
+pub fn msh<'a>(msg: &Message<'a>) -> Result<MshSegment<'a>, Hl7ParseError> {
+    let seg = msg.segments_by_name("MSH").unwrap()[0];
+    let segment =
+        MshSegment::parse(seg.source, &msg.get_separators()).expect("Failed to parse MSH segment");
+    Ok(segment)
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
-    
-    // Normally message would come over the wire from a remote service etc.  
+    // Normally message would come over the wire from a remote service etc.
     // Consider using the hl7-mllp-code crate or similar to make building those network services easier.
     let hl7_string = get_sample_message();
 
     // Parse the string into a structured entity
     let message = Message::try_from(hl7_string)?;
+
+    // Get a strongly-typed segment from generic data
+    let header = msh(&message).expect("Failed to extract MSH");
+    let send_fac = header.msh_4_sending_facility.unwrap().source;
+    assert_eq!(send_fac, message.segments[0].fields[3].source);
 
     // We can deep query message fields using the `query` functionality
     let postcode = message.query("PID.F11.C5"); // Field 11, Component 5

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,121 +2,16 @@
  A short example demonstrating one way to use this library for HL7 processing.
 */
 
-use rusthl7::{
-    escape_sequence::EscapeSequence, fields::Field, message::Message, separators::Separators,
-    Hl7ParseError,
-};
-use std::{convert::TryFrom, error::Error, fmt::Display};
-
-/// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
-/// Given the importance of this segment for driving application behaviour, it gets the special treatment
-/// of a fully typed segment, not just a bag of fields....
-#[derive(Debug, PartialEq)]
-pub struct MshSegment<'a> {
-    pub source: &'a str,
-    //this initial layout largely stolen from the _other_ hl7 crate: https://github.com/njaremko/hl7
-    pub msh_1_field_separator: char,
-    pub msh_2_encoding_characters: Separators,
-    pub msh_3_sending_application: Option<Field<'a>>,
-    pub msh_4_sending_facility: Option<Field<'a>>,
-    pub msh_5_receiving_application: Option<Field<'a>>,
-    pub msh_6_receiving_facility: Option<Field<'a>>,
-    pub msh_7_date_time_of_message: Field<'a>,
-    pub msh_8_security: Option<Field<'a>>,
-    pub msh_9_message_type: Field<'a>,
-    pub msh_10_message_control_id: Field<'a>,
-    pub msh_11_processing_id: Field<'a>,
-    pub msh_12_version_id: Field<'a>,
-    pub msh_13_sequence_number: Option<Field<'a>>,
-    pub msh_14_continuation_pointer: Option<Field<'a>>,
-    pub msh_15_accept_acknowledgment_type: Option<Field<'a>>,
-    pub msh_16_application_acknowledgment_type: Option<Field<'a>>,
-    pub msh_17_country_code: Option<Field<'a>>,
-    pub msh_18_character_set: Option<Field<'a>>, //TODO: repeating field
-    pub msh_19_principal_language_of_message: Option<Field<'a>>,
-    // pub msh_20_alternate_character_set_handling_scheme: Option<Field<'a>>,
-    // pub msh_21_message_profile_identifier: Option<Vec<Field<'a>>>,
-    // pub msh_22_sending_responsible_organization: Option<Field<'a>>,
-    // pub msh_23_receiving_responsible_organization: Option<Field<'a>>,
-    // pub msh_24_sending_network_address: Option<Field<'a>>,
-    // pub msh_25_receiving_network_address: Option<Field<'a>>,
-}
-
-impl<'a> MshSegment<'a> {
-    pub fn parse<S: Into<&'a str>>(
-        input: S,
-        delims: &Separators,
-    ) -> Result<MshSegment<'a>, Hl7ParseError> {
-        let input = input.into();
-
-        let mut fields = input.split(delims.field);
-
-        assert!(fields.next().unwrap() == "MSH");
-
-        let _ = fields.next(); //consume the delimiter chars
-
-        let msh = MshSegment {
-            source: input,
-            msh_1_field_separator: delims.field,
-            msh_2_encoding_characters: delims.to_owned(),
-            msh_3_sending_application: Field::parse_optional(fields.next(), delims)?,
-            msh_4_sending_facility: Field::parse_optional(fields.next(), delims)?,
-            msh_5_receiving_application: Field::parse_optional(fields.next(), delims)?,
-            msh_6_receiving_facility: Field::parse_optional(fields.next(), delims)?,
-            msh_7_date_time_of_message: Field::parse_mandatory(fields.next(), delims)?,
-            msh_8_security: Field::parse_optional(fields.next(), delims)?,
-            msh_9_message_type: Field::parse_mandatory(fields.next(), delims)?,
-            msh_10_message_control_id: Field::parse_mandatory(fields.next(), delims)?,
-            msh_11_processing_id: Field::parse_mandatory(fields.next(), delims)?,
-            msh_12_version_id: Field::parse_mandatory(fields.next(), delims)?,
-            msh_13_sequence_number: Field::parse_optional(fields.next(), delims)?,
-            msh_14_continuation_pointer: Field::parse_optional(fields.next(), delims)?,
-            msh_15_accept_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
-            msh_16_application_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
-            msh_17_country_code: Field::parse_optional(fields.next(), delims)?,
-            msh_18_character_set: Field::parse_optional(fields.next(), delims)?,
-            msh_19_principal_language_of_message: Field::parse_optional(fields.next(), delims)?,
-        };
-
-        Ok(msh)
-    }
-}
-/// Common formatter trait implementation for the strongly-typed segment
-impl<'a> Display for MshSegment<'a> {
-    /// Required for to_string() and other formatter consumers
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.source)
-    }
-}
-/// Common clone trait implementation for the strongly-typed segment
-impl<'a> Clone for MshSegment<'a> {
-    /// Creates a new Message object using _the same source_ slice as the original.
-    fn clone(&self) -> Self {
-        let delims = self.msh_2_encoding_characters;
-        MshSegment::parse(self.source, &delims).unwrap()
-    }
-}
-
-/// Extracts header element for external use
-pub fn msh<'a>(msg: &Message<'a>) -> Result<MshSegment<'a>, Hl7ParseError> {
-    let seg = msg.segments_by_name("MSH").unwrap()[0];
-    let segment =
-        MshSegment::parse(seg.source, &msg.get_separators()).expect("Failed to parse MSH segment");
-    Ok(segment)
-}
+use rusthl7::{escape_sequence::EscapeSequence, message::Message};
+use std::{convert::TryFrom, error::Error};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Normally message would come over the wire from a remote service etc.
-    // Consider using the hl7-mllp-code crate or similar to make building those network services easier.
+    // Consider using the hl7-mllp-codec crate or similar to make building those network services easier.
     let hl7_string = get_sample_message();
 
     // Parse the string into a structured entity
     let message = Message::try_from(hl7_string)?;
-
-    // Get a strongly-typed segment from generic data
-    let header = msh(&message).expect("Failed to extract MSH");
-    let send_fac = header.msh_4_sending_facility.unwrap().source;
-    assert_eq!(send_fac, message.segments[0].fields[3].source);
 
     // We can deep query message fields using the `query` functionality
     let postcode = message.query("PID.F11.C5"); // Field 11, Component 5

--- a/examples/typed_segment.rs
+++ b/examples/typed_segment.rs
@@ -1,0 +1,123 @@
+/*!
+ A short example demonstrating one way to use this library for HL7 processing.
+*/
+
+use rusthl7::{fields::Field, message::Message, separators::Separators,Hl7ParseError};
+use std::{convert::TryFrom, error::Error, fmt::Display};
+
+/// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
+/// Given the importance of this segment for driving application behaviour, it gets the special treatment
+/// of a fully typed segment, not just a bag of fields....
+#[derive(Debug, PartialEq)]
+pub struct MshSegment<'a> {
+    pub source: &'a str,
+    //this initial layout largely stolen from the _other_ hl7 crate: https://github.com/njaremko/hl7
+    pub msh_1_field_separator: char,
+    pub msh_2_encoding_characters: Separators,
+    pub msh_3_sending_application: Option<Field<'a>>,
+    pub msh_4_sending_facility: Option<Field<'a>>,
+    pub msh_5_receiving_application: Option<Field<'a>>,
+    pub msh_6_receiving_facility: Option<Field<'a>>,
+    pub msh_7_date_time_of_message: Field<'a>,
+    pub msh_8_security: Option<Field<'a>>,
+    pub msh_9_message_type: Field<'a>,
+    pub msh_10_message_control_id: Field<'a>,
+    pub msh_11_processing_id: Field<'a>,
+    pub msh_12_version_id: Field<'a>,
+    pub msh_13_sequence_number: Option<Field<'a>>,
+    pub msh_14_continuation_pointer: Option<Field<'a>>,
+    pub msh_15_accept_acknowledgment_type: Option<Field<'a>>,
+    pub msh_16_application_acknowledgment_type: Option<Field<'a>>,
+    pub msh_17_country_code: Option<Field<'a>>,
+    pub msh_18_character_set: Option<Field<'a>>, //TODO: repeating field
+    pub msh_19_principal_language_of_message: Option<Field<'a>>,
+    // pub msh_20_alternate_character_set_handling_scheme: Option<Field<'a>>,
+    // pub msh_21_message_profile_identifier: Option<Vec<Field<'a>>>,
+    // pub msh_22_sending_responsible_organization: Option<Field<'a>>,
+    // pub msh_23_receiving_responsible_organization: Option<Field<'a>>,
+    // pub msh_24_sending_network_address: Option<Field<'a>>,
+    // pub msh_25_receiving_network_address: Option<Field<'a>>,
+}
+
+impl<'a> MshSegment<'a> {
+    pub fn parse<S: Into<&'a str>>(
+        input: S,
+        delims: &Separators,
+    ) -> Result<MshSegment<'a>, Hl7ParseError> {
+        let input = input.into();
+
+        let mut fields = input.split(delims.field);
+
+        assert!(fields.next().unwrap() == "MSH");
+
+        let _ = fields.next(); //consume the delimiter chars
+
+        let msh = MshSegment {
+            source: input,
+            msh_1_field_separator: delims.field,
+            msh_2_encoding_characters: delims.to_owned(),
+            msh_3_sending_application: Field::parse_optional(fields.next(), delims)?,
+            msh_4_sending_facility: Field::parse_optional(fields.next(), delims)?,
+            msh_5_receiving_application: Field::parse_optional(fields.next(), delims)?,
+            msh_6_receiving_facility: Field::parse_optional(fields.next(), delims)?,
+            msh_7_date_time_of_message: Field::parse_mandatory(fields.next(), delims)?,
+            msh_8_security: Field::parse_optional(fields.next(), delims)?,
+            msh_9_message_type: Field::parse_mandatory(fields.next(), delims)?,
+            msh_10_message_control_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_11_processing_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_12_version_id: Field::parse_mandatory(fields.next(), delims)?,
+            msh_13_sequence_number: Field::parse_optional(fields.next(), delims)?,
+            msh_14_continuation_pointer: Field::parse_optional(fields.next(), delims)?,
+            msh_15_accept_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
+            msh_16_application_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
+            msh_17_country_code: Field::parse_optional(fields.next(), delims)?,
+            msh_18_character_set: Field::parse_optional(fields.next(), delims)?,
+            msh_19_principal_language_of_message: Field::parse_optional(fields.next(), delims)?,
+        };
+
+        Ok(msh)
+    }
+}
+/// Common formatter trait implementation for the strongly-typed segment
+impl<'a> Display for MshSegment<'a> {
+    /// Required for to_string() and other formatter consumers
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.source)
+    }
+}
+/// Common clone trait implementation for the strongly-typed segment
+impl<'a> Clone for MshSegment<'a> {
+    /// Creates a new Message object using _the same source_ slice as the original.
+    fn clone(&self) -> Self {
+        let delims = self.msh_2_encoding_characters;
+        MshSegment::parse(self.source, &delims).unwrap()
+    }
+}
+
+/// Extracts header element for external use
+pub fn msh<'a>(msg: &Message<'a>) -> Result<MshSegment<'a>, Hl7ParseError> {
+    let seg = msg.segments_by_name("MSH").unwrap()[0];
+    let segment =
+        MshSegment::parse(seg.source, &msg.get_separators()).expect("Failed to parse MSH segment");
+    Ok(segment)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Normally message would come over the wire from a remote service etc.
+    // Consider using the hl7-mllp-codec crate or similar to make building those network services easier.
+    let hl7_string = get_sample_message();
+
+    // Parse the string into a structured entity
+    let message = Message::try_from(hl7_string)?;
+
+    // Get a strongly-typed segment from generic data
+    let header = msh(&message).expect("Failed to extract MSH");
+    let send_fac = header.msh_4_sending_facility.unwrap().source;
+    assert_eq!(send_fac, message.segments[0].fields[3].source);
+
+    Ok(())
+}
+
+fn get_sample_message() -> &'static str {
+    "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rPID|||555-44-4444||EVERYWOMAN^EVE^E^^^^L|JONES|19620320|F|||153 FERNWOOD DR.^^STATESVILLE^OH^35292||(206)3345232|(206)752-121||||AC555444444||67-A4335^OH^20030520\rOBR|1|845439^GHH OE|1045813^GHH LAB|15545^GLUCOSE|||200202150730|||||||||555-55-5555^PRIMARY^PATRICIA P^^^^MD^^|||||||Joes Obs \\T\\ Gynae||F||||||444-44-4444^HIPPOCRATES^HOWARD H^^^^MD\rOBX|1|SN|1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN||^182|mg/dl|70_105|H|||F"
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,4 @@
-use super::segments::{MshSegment, Segment};
+use super::segments::Segment;
 use super::separators::Separators;
 use super::*;
 use std::convert::TryFrom;
@@ -28,13 +28,6 @@ impl<'a> Message<'a> {
             segments,
             separators
         }
-    }
-    /// Extracts header element for external use
-    pub fn msh(&self) -> Result<MshSegment, Hl7ParseError> {
-        let seg = self.segments_by_name("MSH").unwrap()[0];
-        let segment =
-            MshSegment::parse(seg.source, &self.separators).expect("Failed to parse MSH segment");
-        Ok(segment)
     }
 
     /// Extracts generic elements for external use by matching first field to name
@@ -223,14 +216,6 @@ mod tests {
     }
 
     #[test]
-    fn ensure_msh_is_returned() -> Result<(), Hl7ParseError> {
-        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment";
-        let msg = Message::try_from(hl7)?;
-
-        assert_eq!(msg.msh().unwrap().msh_1_field_separator, '|');
-        Ok(())
-    }
-    #[test]
     fn ensure_segments_convert_to_vectors() -> Result<(), Hl7ParseError> {
         let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4\rOBR|segment";
         let msg = Message::try_from(hl7)?;
@@ -250,8 +235,8 @@ mod tests {
         let dolly = msg.clone();
         let dolly = dolly.to_owned();
         assert_eq!(
-            msg.msh().unwrap().msh_7_date_time_of_message,
-            dolly.msh().unwrap().msh_7_date_time_of_message
+            msg.query("MSH.F7"),
+            dolly.query("MSH.F7")
         );
         Ok(())
     }

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -2,12 +2,6 @@ use super::{fields::Field, separators::Separators, Hl7ParseError};
 use std::fmt::Display;
 use std::ops::Index;
 
-/// All defined segment types
-// pub enum Segments<'a> {
-//     Generic(Segment<'a>),
-//     MSH(MshSegment<'a>),
-// }
-
 /// A generic bag o' fields, representing an arbitrary segment.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Segment<'a> {
@@ -171,101 +165,6 @@ impl<'a> Index<String> for Segment<'a> {
     }
 }
 
-/// The most important Segment, almost all HL7 messages have an MSH (MLLP simple ack I'm looking at you).
-/// Given the importance of this segment for driving application behaviour, it gets the special treatment
-/// of a fully typed segment, not just a bag of fields....
-#[derive(Debug, PartialEq)]
-pub struct MshSegment<'a> {
-    pub source: &'a str,
-    //this initial layout largely stolen from the _other_ hl7 crate: https://github.com/njaremko/hl7
-    pub msh_1_field_separator: char,
-    pub msh_2_encoding_characters: Separators,
-    pub msh_3_sending_application: Option<Field<'a>>,
-    pub msh_4_sending_facility: Option<Field<'a>>,
-    pub msh_5_receiving_application: Option<Field<'a>>,
-    pub msh_6_receiving_facility: Option<Field<'a>>,
-    pub msh_7_date_time_of_message: Field<'a>,
-    pub msh_8_security: Option<Field<'a>>,
-    pub msh_9_message_type: Field<'a>,
-    pub msh_10_message_control_id: Field<'a>,
-    pub msh_11_processing_id: Field<'a>,
-    pub msh_12_version_id: Field<'a>,
-    pub msh_13_sequence_number: Option<Field<'a>>,
-    pub msh_14_continuation_pointer: Option<Field<'a>>,
-    pub msh_15_accept_acknowledgment_type: Option<Field<'a>>,
-    pub msh_16_application_acknowledgment_type: Option<Field<'a>>,
-    pub msh_17_country_code: Option<Field<'a>>,
-    pub msh_18_character_set: Option<Field<'a>>, //TODO: repeating field
-    pub msh_19_principal_language_of_message: Option<Field<'a>>,
-    // pub msh_20_alternate_character_set_handling_scheme: Option<Field<'a>>,
-    // pub msh_21_message_profile_identifier: Option<Vec<Field<'a>>>,
-    // pub msh_22_sending_responsible_organization: Option<Field<'a>>,
-    // pub msh_23_receiving_responsible_organization: Option<Field<'a>>,
-    // pub msh_24_sending_network_address: Option<Field<'a>>,
-    // pub msh_25_receiving_network_address: Option<Field<'a>>,
-}
-
-impl<'a> MshSegment<'a> {
-    pub fn parse<S: Into<&'a str>>(
-        input: S,
-        delims: &Separators,
-    ) -> Result<MshSegment<'a>, Hl7ParseError> {
-        let input = input.into();
-
-        let mut fields = input.split(delims.field);
-
-        assert!(fields.next().unwrap() == "MSH");
-
-        let _ = fields.next(); //consume the delimiter chars
-
-        let msh = MshSegment {
-            source: input,
-            msh_1_field_separator: delims.field,
-            msh_2_encoding_characters: delims.to_owned(),
-            msh_3_sending_application: Field::parse_optional(fields.next(), delims)?,
-            msh_4_sending_facility: Field::parse_optional(fields.next(), delims)?,
-            msh_5_receiving_application: Field::parse_optional(fields.next(), delims)?,
-            msh_6_receiving_facility: Field::parse_optional(fields.next(), delims)?,
-            msh_7_date_time_of_message: Field::parse_mandatory(fields.next(), delims)?,
-            msh_8_security: Field::parse_optional(fields.next(), delims)?,
-            msh_9_message_type: Field::parse_mandatory(fields.next(), delims)?,
-            msh_10_message_control_id: Field::parse_mandatory(fields.next(), delims)?,
-            msh_11_processing_id: Field::parse_mandatory(fields.next(), delims)?,
-            msh_12_version_id: Field::parse_mandatory(fields.next(), delims)?,
-            msh_13_sequence_number: Field::parse_optional(fields.next(), delims)?,
-            msh_14_continuation_pointer: Field::parse_optional(fields.next(), delims)?,
-            msh_15_accept_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
-            msh_16_application_acknowledgment_type: Field::parse_optional(fields.next(), delims)?,
-            msh_17_country_code: Field::parse_optional(fields.next(), delims)?,
-            msh_18_character_set: Field::parse_optional(fields.next(), delims)?,
-            msh_19_principal_language_of_message: Field::parse_optional(fields.next(), delims)?,
-        };
-
-        Ok(msh)
-    }
-
-    /// Export source to str
-    #[inline]
-    pub fn as_str(&self) -> &'a str {
-        self.source
-    }
-}
-
-impl<'a> Display for MshSegment<'a> {
-    /// Required for to_string() and other formatter consumers
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.source)
-    }
-}
-
-impl<'a> Clone for MshSegment<'a> {
-    /// Creates a new Message object using _the same source_ slice as the original.
-    fn clone(&self) -> Self {
-        let delims = self.msh_2_encoding_characters;
-        MshSegment::parse(self.source, &delims).unwrap()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{message::Message, segments::*, separators::Separators, Hl7ParseError};
@@ -297,50 +196,6 @@ mod tests {
         assert_eq!(c, f);
         assert_eq!(s, "segment");
         assert_eq!(oob, "");
-    }
-    #[test]
-    fn ensure_msh_fields_are_populated() -> Result<(), Hl7ParseError> {
-        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
-        let delims = Separators::default();
-
-        let msh = MshSegment::parse(hl7, &delims)?;
-
-        assert_eq!(msh.msh_1_field_separator, '|');
-
-        let msh3 = msh
-            .msh_3_sending_application
-            .ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
-        assert_eq!(msh3.value(), "GHH LAB");
-
-        let msh4 = msh
-            .msh_4_sending_facility
-            .ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
-        assert_eq!(msh4.value(), "ELAB-3");
-
-        let msh5 = msh
-            .msh_5_receiving_application
-            .ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
-        assert_eq!(msh5.value(), "GHH OE");
-
-        let msh6 = msh
-            .msh_6_receiving_facility
-            .ok_or(Hl7ParseError::Generic("Parse Error".to_string()))?;
-        assert_eq!(msh6.value(), "BLDG4");
-
-        assert_eq!(msh.msh_8_security, None); //blank field check
-        assert_eq!(msh.msh_12_version_id.value(), "2.4"); //we got to the end ok
-        Ok(())
-    }
-
-    #[test]
-    fn ensure_msh_clones_correctly() -> Result<(), Hl7ParseError> {
-        let hl7 = "MSH|^~\\&|GHH LAB|ELAB-3|GHH OE|BLDG4|200202150930||ORU^R01|CNTRL-3456|P|2.4";
-        let delims = Separators::default();
-
-        let msh = MshSegment::parse(hl7, &delims)?;
-        let dolly = msh.clone();
-        assert_eq!(msh, dolly);
-        Ok(())
     }
 
     #[cfg(feature = "string_index")]


### PR DESCRIPTION
Strongly-typed message header segment does not conform with generic
segment semantics, nor does it serve a specific purpose in the lib.

Remove the MshSegment struct and implementations from the main
library sources, place into the demo example to show conversion
semantics and accessor mechanism