### PR TITLE
feat #16 - Lots of work on the docs, and some general cleanup

### DIFF
--- a/benches/simple_parse.rs
+++ b/benches/simple_parse.rs
@@ -19,7 +19,7 @@ fn get_segments_by_name(c: &mut Criterion) {
         let m = Message::try_from(get_sample_message()).unwrap();
 
         b.iter(|| {
-            let _segs = m.segments_by_name("OBR").unwrap();
+            let _segs = m.segments_by_identifier("OBR").unwrap();
             //assert!(segs.len() == 1);
         })
     });

--- a/examples/typed_segment.rs
+++ b/examples/typed_segment.rs
@@ -96,7 +96,7 @@ impl<'a> Clone for MshSegment<'a> {
 
 /// Extracts header element for external use
 pub fn msh<'a>(msg: &Message<'a>) -> Result<MshSegment<'a>, Hl7ParseError> {
-    let seg = msg.segments_by_name("MSH").unwrap()[0];
+    let seg = msg.segments_by_identifier("MSH").unwrap()[0];
     let segment =
         MshSegment::parse(seg.source, &msg.get_separators()).expect("Failed to parse MSH segment");
     Ok(segment)

--- a/src/separators.rs
+++ b/src/separators.rs
@@ -4,16 +4,20 @@ use std::str::FromStr;
 
 /// A helper struct to store the separator (delimiter) characters used to parse this message.
 /// Note that HL7 allows each _message_ to define it's own separators, although most messages
-/// use a default set (available from `Separators::default()`)
+/// use a default set (available from [`Separators::default()`])
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Separators {
     /// constant value, spec fixed to '\r' (ASCII 13, 0x0D)
     pub segment: char,
+    /// Field separator char, defaults to `|`
     pub field: char,
+    /// Field repeat separator char, defaults to `~`
     pub repeat: char,
+    /// Component separator char, defaults to `^`
     pub component: char,
+    /// Sub-Component separator char, defaults to `&`
     pub subcomponent: char,
-
+    /// Character used to wrap an [`EscapeSequence`], defaults to `\` (a single back slash)
     pub escape_char: char,
 }
 


### PR DESCRIPTION
A couple of public API changes in here:
 - `segments_by_name()` renamed to `segments_by_identifier()`... Naming is hard, and the spec uses the word `identifier` and `segment ID` so gaining consistency there.
   - Do we want to mark the old name as `deprecated` and point top the new function, or is it not actually being used in the wild?
 - `Field::value()` marked as deprecated as a full dupe of `Field::as_str()`
 - As part of the information hiding I've removed public visibility from some struct members, let me know if you were using the direct access for anything